### PR TITLE
fixed reading unicode strings

### DIFF
--- a/src/ue4/reader/FArchive.ts
+++ b/src/ue4/reader/FArchive.ts
@@ -305,7 +305,7 @@ export abstract class FArchive {
                 dat.push(this.readUInt16())
             if (this.readUInt16() !== 0)
                 throw new ParserException("Serialized FString is not null-terminated", this)
-            return String(Buffer.from(dat))
+            return Buffer.from(dat).toString("utf-16le")
         } else {
             if (length === 0) return ""
             const str = this.read(length - 1).toString("utf-8")


### PR DESCRIPTION
Example:
```node
const buffer = Buffer.from('TQBhAGwAZQB0AO0AbgAgAGQAZQAgAHMAaQBnAGkAbABvACAAbgBlAHYAYQBkAG8A', 'base64');
const strBefore = String(buffer);
const strAfter = buffer.toString('utf-16le');
console.log(strBefore); // > Malet�n de sigilo nevado
console.log(strAfter);  // > Maletín de sigilo nevado
```